### PR TITLE
feat: Configure project for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/configure-pages@v4
         
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
         
       - name: Build with Next.js
         run: pnpm run build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  basePath: '/karanbadlani-portfolio',
   output: 'export',
   trailingSlash: true,
   images: {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portfolio",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://Johnny001-DS.github.io/karanbadlani-portfolio",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
This commit configures the Next.js project for deployment to GitHub Pages.

- Adds a `basePath` to `next.config.ts` to handle the repository sub-path.
- Adds a `homepage` URL to `package.json`.
- Creates a `.nojekyll` file to disable Jekyll processing on GitHub Pages.
- Removes the `--no-frozen-lockfile` flag from the `pnpm install` command in the GitHub Actions workflow for more reliable builds.