### PR TITLE
fix: Correct asset paths for GitHub Pages deployment

### DIFF
--- a/src/components/experience/ExperienceCard.tsx
+++ b/src/components/experience/ExperienceCard.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { Calendar, ChevronRight } from 'lucide-react';
 import { ExperienceCardProps } from '@/types';
+import { useRouter } from 'next/router';
 
 const ExperienceCard: React.FC<ExperienceCardProps> = ({ experience, onSelect, isActive = false }) => {
+    const { basePath } = useRouter();
     const cardClasses = `relative bg-white dark:bg-gray-800 p-6 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 ${
       isActive ? 'border-l-4 border-blue-600 dark:border-blue-400' : ''
     }`;
@@ -16,7 +18,7 @@ const ExperienceCard: React.FC<ExperienceCardProps> = ({ experience, onSelect, i
           <div className="flex-shrink-0 mr-4">
             <div className="w-12 h-12 bg-gray-100 dark:bg-gray-700 rounded-md overflow-hidden">
               <img 
-                src={experience.logo} 
+                src={`${basePath}${experience.logo}`}
                 alt={experience.company} 
                 className="w-full h-full object-cover"
               />

--- a/src/components/experience/ExperienceDetails.tsx
+++ b/src/components/experience/ExperienceDetails.tsx
@@ -3,8 +3,10 @@ import { Calendar } from 'lucide-react';
 import { ExperienceDetailsProps } from '@/types';
 import { MapPin, Briefcase, Code, Award, MessageSquare } from 'lucide-react';
 import { X } from 'lucide-react';
+import { useRouter } from 'next/router';
 
 const ExperienceDetails: React.FC<ExperienceDetailsProps> = ({ experience, onClose }) => {
+    const { basePath } = useRouter();
     if (!experience) return null;
     
     return (
@@ -32,7 +34,7 @@ const ExperienceDetails: React.FC<ExperienceDetailsProps> = ({ experience, onClo
                 <div className="mr-4">
                   <div className="w-16 h-16 bg-gray-100 dark:bg-gray-800 rounded-md flex items-center justify-center">
                     <img 
-                      src={experience.logo} 
+                      src={`${basePath}${experience.logo}`}
                       alt={experience.company} 
                       className="w-12 h-12 object-contain"
                     />

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,7 +1,9 @@
 import { ArrowDownCircle } from "lucide-react";
 import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
 
 const Hero: React.FC = () => {
+    const { basePath } = useRouter();
     const scrollToAbout = () => {
       const element = document.getElementById('about');
       if (element) {
@@ -94,7 +96,7 @@ const Hero: React.FC = () => {
                     View My Work
                   </a>
                   <a 
-                    href="/app/files/KB_DS_Boston.pdf"
+                    href={`${basePath}/app/files/KB_DS_Boston.pdf`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="px-8 py-4 bg-white dark:bg-gray-800 border border-blue-600 dark:border-blue-400 text-blue-600 dark:text-blue-400 font-medium rounded-lg shadow-md hover:shadow-lg transform hover:-translate-y-1 transition-all duration-300"
@@ -113,7 +115,7 @@ const Hero: React.FC = () => {
                 
                 <div className="relative w-64 h-64 md:w-80 md:h-80 bg-gray-100 dark:bg-gray-800 rounded-2xl overflow-hidden shadow-xl transform rotate-3 hover:rotate-0 transition-all duration-500">
                   <img 
-                    src="/app/images/misc/KB.jpeg"
+                    src={`${basePath}/app/images/misc/KB.jpeg`}
                     alt="Karan Badlani" 
                     className="w-full h-full object-cover rounded-2xl"
                   />

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,13 +1,11 @@
 import { Experience } from "@/types/index";
 
-const imgRoot = "/app/images/experiences/"
-
 export const experiences: Experience[] = 
 [
   {
     id: 1,
     company: "MFS Investment Management",
-    logo: imgRoot + "mfs_logo.png",
+    logo: "/app/images/experiences/mfs_logo.png",
     position: "Data Science Analyst",
     period: "January 2025 - July 2025",
     location: "Boston, MA",
@@ -40,7 +38,7 @@ export const experiences: Experience[] =
   {
     id: 2,
     company: "Khoury College of Computer Sciences, Northeastern University",
-    logo: imgRoot + "northeastern_logo.png",
+    logo: "/app/images/experiences/northeastern_logo.png",
     position: "Research and Teaching Assistant",
     period: "May 2024 - December 2024",
     location: "Boston, MA",
@@ -65,7 +63,7 @@ export const experiences: Experience[] =
   {
     id: 3,
     company: "InfoCepts",
-    logo: imgRoot + "infocepts_logo.jpeg",
+    logo: "/app/images/experiences/infocepts_logo.jpeg",
     position: "Data Scientist",
     period: "December 2022 - June 2023",
     location: "India",
@@ -95,7 +93,7 @@ export const experiences: Experience[] =
   {
     id: 4,
     company: "Shri Ramdeobaba College of Engineering",
-    logo: imgRoot + "srcoe_logo.png",
+    logo: "/app/images/experiences/srcoe_logo.png",
     position: "Research Scientist",
     period: "January 2022 - June 2022",
     location: "India",


### PR DESCRIPTION
This commit fixes broken image and file links that were not loading on the deployed GitHub Pages site.

- Uses the `useRouter` hook to get the `basePath` and prepends it to `href` and `src` attributes in the Hero and Experience components.
- This ensures that all assets are loaded correctly from the repository sub-path (`/karanbadlani-portfolio`).
- Refactors the experience data file to remove a redundant variable.