### PR TITLE
fix: Correct favicon path for GitHub Pages deployment

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,9 +1,14 @@
 import { Html, Head, Main, NextScript } from 'next/document';
+import nextConfig from '../../next.config';
+
+const basePath = nextConfig.basePath || '';
 
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="icon" href={`${basePath}/favicon.ico`} />
+      </Head>
       <body className="antialiased">
         <Main />
         <NextScript />


### PR DESCRIPTION
This commit fixes the favicon not loading on the deployed site. It adds an explicit link to the favicon in `_document.tsx` and prepends the `basePath` to ensure the path is correct for the GitHub Pages subdirectory.