### PR TITLE
Fix maintenance redirect timing and reliability

### DIFF
--- a/src/components/layout/Maintenance.tsx
+++ b/src/components/layout/Maintenance.tsx
@@ -1,8 +1,27 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
-import { Github, Linkedin, Mail } from 'lucide-react';
+import { Github, Linkedin, Mail, Loader2 } from 'lucide-react';
 
 const Maintenance = () => {
+  const [showRedirectMessage, setShowRedirectMessage] = useState(false);
+
+  useEffect(() => {
+    // Show the message after 2 seconds so the user has time to read it before redirect
+    const messageTimer = setTimeout(() => {
+      setShowRedirectMessage(true);
+    }, 2000);
+
+    // Redirect to GitHub after 5 seconds total (3 seconds after message appears)
+    const redirectTimer = setTimeout(() => {
+      window.location.href = 'https://github.com/Johnny001-DS';
+    }, 5000);
+
+    return () => {
+      clearTimeout(messageTimer);
+      clearTimeout(redirectTimer);
+    };
+  }, []);
+
   return (
     <>
       <Head>
@@ -10,7 +29,7 @@ const Maintenance = () => {
         <meta name="description" content="Site currently under maintenance" />
       </Head>
 
-      <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-300">
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 text-center bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-300 relative">
         <div className="max-w-md w-full space-y-8">
           {/* Icon or Graphic could go here */}
           <div className="space-y-4">
@@ -56,6 +75,29 @@ const Maintenance = () => {
             </div>
           </div>
         </div>
+
+        {/* Redirect Modal */}
+        {showRedirectMessage && (
+          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[9999] flex items-center justify-center p-4 animate-in fade-in duration-300">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-sm w-full border border-gray-200 dark:border-gray-700 text-center space-y-4">
+              <div className="mx-auto bg-blue-100 dark:bg-blue-900/30 p-3 rounded-full w-fit">
+                <Github className="w-8 h-8 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                  Redirecting to GitHub
+                </h3>
+                <p className="mt-2 text-gray-600 dark:text-gray-300">
+                  Hey I&apos;m currently revamping my portfolio but let me direct to you my GitHub profile.
+                </p>
+              </div>
+              <div className="flex items-center justify-center space-x-2 text-sm text-gray-500 dark:text-gray-400">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Redirecting shortly...</span>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
Updated the maintenance redirect logic to be more reliable and user-friendly.

The implementation now:
1. Shows the "Redirecting to GitHub" modal after 2 seconds (giving users time to read it).
2. Redirects to https://github.com/Johnny001-DS after 5 seconds total.
3. Uses a high z-index to ensure the modal is always visible.
4. Properly cleans up timers to prevent potential issues.

This addresses the "Not working" feedback by ensuring the redirect happens reliably at the 5-second mark, with the message appearing beforehand.

---
*PR created automatically by Jules for task [10599651013272116306](https://jules.google.com/task/10599651013272116306) started by @Johnny001-DS*